### PR TITLE
bugfix: Fixed Id being passed to transaction sender class

### DIFF
--- a/src/lib/Federator.ts
+++ b/src/lib/Federator.ts
@@ -43,13 +43,13 @@ export default abstract class Federator {
 
   async getCurrentChainId() {
     if (this.chainId === undefined) {
-      this.chainId = Number(await this.getMainChainWeb3().eth.net.getId());
+      this.chainId = Number(await this.getMainChainWeb3().eth.getChainId());
     }
     return this.chainId;
   }
 
   async getChainId(client: web3) {
-    return client.eth.net.getId();
+    return client.eth.getChainId();
   }
 
   getLastBlockPath(mainChainId: number, sideChainId: number): string {
@@ -119,7 +119,7 @@ export default abstract class Federator {
       this.logger.trace(`${this.constructor.name} from ${this.config.mainchain.chainId} to ${sideChainConfig.chainId}`);
       this.resetRetries();
       const sideChainWeb3 = this.getWeb3(sideChainConfig.host);
-      const transactionSender = new TransactionSender(sideChainWeb3, this.logger, this.config);
+      const transactionSender = new TransactionSender(sideChainWeb3, this.logger, this.config, sideChainConfig.chainId);
       const federationFactory = new FederationFactory();
       const fedContract = await federationFactory.createInstance(sideChainConfig, this.config.privateKey);
       const from = await transactionSender.getAddress(this.config.privateKey);

--- a/src/lib/Heartbeat.ts
+++ b/src/lib/Heartbeat.ts
@@ -33,7 +33,7 @@ export class Heartbeat {
     this.mainWeb3 = new Web3(config.mainchain.host);
 
     this.federationFactory = new FederationFactory();
-    this.transactionSender = new TransactionSender(this.mainWeb3, this.logger, this.config);
+    this.transactionSender = new TransactionSender(this.mainWeb3, this.logger, this.config, config.mainchain.chainId);
     this.lastBlockPath = `${config.storagePath || __dirname}/heartBeatLastBlock.txt`;
     this.sideChains = [];
     for (const sideChainConfig of config.sidechain) {

--- a/src/lib/TransactionSender.ts
+++ b/src/lib/TransactionSender.ts
@@ -24,11 +24,13 @@ export class TransactionSender {
   manuallyCheck: any;
   etherscanApiKey: any;
   debuggingMode: any;
+  config: any;
 
-  constructor(client, logger, config) {
+  constructor(client, logger, config, chainId) {
     this.client = client;
     this.logger = logger;
-    this.chainId = null;
+    this.config = config;
+    this.chainId = chainId;
     this.manuallyCheck = `${config.storagePath || __dirname}/manuallyCheck.txt`;
     this.etherscanApiKey = config.etherscanApiKey;
     this.debuggingMode = false;
@@ -128,8 +130,13 @@ export class TransactionSender {
   }
 
   async getChainId() {
+    console.info('getChainId', this.chainId);
     if (this.chainId === undefined || this.chainId === null) {
-      this.chainId = Number(await this.client.eth.net.getId());
+      this.logger.error('chainId is undefined, trying to get it from the node');
+      this.chainId = Number(await this.client.eth.getChainId());
+    }
+    if (this.chainId === undefined || this.chainId === null) {
+      throw new Error('chainId is undefined, please check your config files and restart');
     }
     return this.chainId;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -168,7 +168,7 @@ export async function getHeartbeatPollingInterval({ host, runHeartbeatEvery = 1 
   const isNodeOnline = await verifyEndpoint(host);
   if(isNodeOnline) {
     const web3 = new Web3(host);
-    const chainId = await web3.eth.net.getId();
+    const chainId = await web3.eth.getChainId();
     return [30, 31].includes(Number(chainId)) ? 1000 * 60 * 60 : runHeartbeatEvery * 1000 * 60;
   }
   return runHeartbeatEvery * 1000 * 60;


### PR DESCRIPTION
During initialization of the transaction sender class the chainId was initialized as null and after got from the node using web3js `eth.net.getId()` this method is deprecated since it relies on the EVM `net_version` method.
So was done 2 changes, one the chainId is being passed and set on the TransactionSender constructor and the deprecated method on web3 was changed to the recommended one `eth.getChainId()`.
Also was changed to in case we didin't get the chainId the federator will stop, since it will not be able to vote for the transaction.
