### PR TITLE
fix: update etherscan api version

### DIFF
--- a/src/contracts/Constants.ts
+++ b/src/contracts/Constants.ts
@@ -5,3 +5,4 @@ export const VERSIONS = {
   V1: 'v1',
   V0: 'v0',
 };
+

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,10 @@
+export const CHAIN_IDS = {
+  RSK_MAINNET: 30,
+  RSK_TESTNET: 31,
+  ETHEREUM_MAINNET: 1,
+  ETHEREUM_SEPOLIA: 11155111,
+} as const
+
+export const API_URLS = {
+  ETHERSCAN_API_URL: 'https://api.etherscan.io/v2/api',
+}


### PR DESCRIPTION
## What
- Update Etherscan API version
- Modify `TransactionSender`  to use Etherscan in testnet too

## Why
Yesterday we identified a stuck transaction, when verifying the logs, we noticed the following:
<img width="1368" height="437" alt="image" src="https://github.com/user-attachments/assets/c7fe8367-0b4c-4d7a-ab05-14065f9ec668" />

After checking, it was determined that the issue is that the Etherscan API v1 was deprecated, so the response contained a value that couldn't be processed by the web3 library. While inspecting the code, it was found that the Etherscan API call was only executed in mainnet, so it wasn't possible to reproduce the issue in testnet.

Later, the code was modified to execute this flow in testnet as well, resulting in the following error, which confirmed this was indeed the issue in mainnet:
<img width="2354" height="1096" alt="image" src="https://github.com/user-attachments/assets/e01abdf8-b788-4c99-ad3c-c032260f4e1b" />

However, after making the update, the result was that the specific API call wasn't supported for Sepolia network. This is probably because Etherscan only maintains gas oracles for mainnet. **This is the reason why Ethereum's chain id is hardcoded in the query param in this PR**. These are the calls that proof the previous statement:

** Old API call**
```
curl "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=xxx" | jq       
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   155  100   155    0     0    274      0 --:--:-- --:--:-- --:--:--   274
{
  "status": "0",
  "message": "NOTOK",
  "result": "You are using a deprecated V1 endpoint, switch to Etherscan API V2 using https://docs.etherscan.io/v2-migration"
}
```

** New API call in Sepolia**
```
curl "https://api.etherscan.io/v2/api?chainid=11155111&module=gastracker&action=gasoracle&apikey=xxx" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    86  100    86    0     0     84      0  0:00:01  0:00:01 --:--:--    84
{
  "status": "0",
  "message": "NOTOK",
  "result": "Error! Missing Or invalid Module name (#1)"
}

```

** New API call in Ethereum**
```
curl "https://api.etherscan.io/v2/api?chainid=1&module=gastracker&action=gasoracle&apikey=xxx" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   291  100   291    0     0    505      0 --:--:-- --:--:-- --:--:--   505
{
  "status": "1",
  "message": "OK",
  "result": {
    "LastBlock": "23491964",
    "SafeGasPrice": "1.028660513",
    "ProposeGasPrice": "1.038660513",
    "FastGasPrice": "1.128660513",
    "suggestBaseFee": "1.028660513",
    "gasUsedRatio": "0.574653123117198,0.365802948656701,0.481207545961081,0.583601717436034,0.411697460937687"
  }
}
```

## Important
This PR only fixes the Etherscan related issue, if there are other issues in mainnet, this PR does not solve them.

